### PR TITLE
Allow duplicate emails

### DIFF
--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -65,7 +65,6 @@ class RegisteredUserController extends Controller
                 'lowercase',
                 'email',
                 'max:255',
-                'unique:' . User::class
             ],
             'gender' => [
                 'required',

--- a/app/Http/Requests/Settings/ProfileUpdateRequest.php
+++ b/app/Http/Requests/Settings/ProfileUpdateRequest.php
@@ -25,7 +25,6 @@ class ProfileUpdateRequest extends FormRequest
                 'lowercase',
                 'email',
                 'max:255',
-                Rule::unique(User::class)->ignore($this->user()->id),
             ],
         ];
     }

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -18,7 +18,7 @@ return new class extends Migration
             $table->id();
             $table->string('username')->unique(); // New column (must be unique)
             $table->string('name');
-            $table->string('email')->unique();
+            $table->string('email');
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
             $table->string('profile_image')->nullable();
@@ -31,7 +31,7 @@ return new class extends Migration
         });
 
         Schema::create('password_reset_tokens', function (Blueprint $table) {
-            $table->string('email')->primary();
+            $table->string('email')->index();
             $table->string('token');
             $table->timestamp('created_at')->nullable();
         });

--- a/database/migrations/2025_04_14_000001_drop_unique_email_on_users_table.php
+++ b/database/migrations/2025_04_14_000001_drop_unique_email_on_users_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Exception;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            // Drop the unique index on the email column if it exists
+            try {
+                $table->dropUnique('users_email_unique');
+            } catch (Exception $e) {
+                // Index does not exist; ignore
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->unique('email');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- drop email unique constraint from registration and profile update requests
- remove `unique()` from email column in users migration
- allow multiple password reset tokens per email
- add migration to drop the old email unique index

## Testing
- `php artisan migrate:fresh` *(fails: php not found)*
- `./vendor/bin/pest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684d06e8479c832db44c8a46f462c755