### PR TITLE
Fix migrations and factory

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -29,6 +29,9 @@ class UserFactory extends Factory
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
+            'username' => fake()->unique()->userName(),
+            'gender' => fake()->randomElement(['m', 'f', 'o']),
+            'role' => 'client',
         ];
     }
 

--- a/database/migrations/2025_03_07_143018_add_receiving_bank_to_receiving_bank_table.php
+++ b/database/migrations/2025_03_07_143018_add_receiving_bank_to_receiving_bank_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('receiving_bank', function (Blueprint $table) {
-            $table->string('receiving_bank')->after('account_number'); // Adds column after 'account_number'
+            $table->string('receiving_bank')->nullable()->after('account_number'); // Allows nullable for SQLite compatibility
         });
     }
 

--- a/database/migrations/2025_04_14_000001_drop_unique_email_on_users_table.php
+++ b/database/migrations/2025_04_14_000001_drop_unique_email_on_users_table.php
@@ -3,7 +3,6 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Exception;
 
 return new class extends Migration
 {
@@ -16,7 +15,7 @@ return new class extends Migration
             // Drop the unique index on the email column if it exists
             try {
                 $table->dropUnique('users_email_unique');
-            } catch (Exception $e) {
+            } catch (\Exception $e) {
                 // Index does not exist; ignore
             }
         });


### PR DESCRIPTION
## Summary
- fix drop_unique_email migration error by removing unused Exception import
- make receiving bank column nullable
- populate username, gender, role in UserFactory

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684edb71c66c832da25655b29b173330