### PR TITLE
Add 503 maintenance view

### DIFF
--- a/resources/views/errors/503.blade.php
+++ b/resources/views/errors/503.blade.php
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Website Maintenance</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+            background-color: #f8fafc;
+            color: #333;
+            margin: 0;
+        }
+        .message {
+            text-align: center;
+        }
+        h1 {
+            font-size: 2rem;
+            margin-bottom: 1rem;
+        }
+    </style>
+</head>
+<body>
+    <div class="message">
+        <h1>We'll be back soon!</h1>
+        <p>Our website is currently undergoing scheduled maintenance.</p>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a custom `resources/views/errors/503.blade.php` page so Laravel's maintenance mode shows a friendly notice

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684f2e0ad4e8832d9969b3723311c0fd