### PR TITLE
Add promotion page for client

### DIFF
--- a/app/Http/Controllers/Promotion/PromotionController.php
+++ b/app/Http/Controllers/Promotion/PromotionController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\Promotion;
+
+use App\Http\Controllers\Controller;
+use Inertia\Inertia;
+
+class PromotionController extends Controller
+{
+    public function index()
+    {
+        return Inertia::render('client/promotion');
+    }
+}

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -20,6 +20,7 @@ import {
     MailCheck,
     Package,
     Plus,
+    SmilePlus,
     Store,
     TypeOutline,
     Users,
@@ -105,6 +106,11 @@ const ClientmainNavItems: NavItem[] = [
         title: 'Request Fund',
         url: '/request-fund',
         icon: FileInput,
+    },
+    {
+        title: 'Promotion',
+        url: '/promotion',
+        icon: SmilePlus,
     },
     {
         title: 'Income History',

--- a/resources/js/pages/client/promotion.tsx
+++ b/resources/js/pages/client/promotion.tsx
@@ -1,0 +1,27 @@
+import AppLayout from '@/layouts/app-layout';
+import { Auth, RoleProps, BreadcrumbItem } from '@/types';
+import { Head, usePage } from '@inertiajs/react';
+import Poster from '../../images/1.jpg';
+
+const breadcrumbs: BreadcrumbItem[] = [
+    {
+        title: 'Promotion',
+        href: '/promotion',
+    },
+];
+
+interface PageProps {
+    auth: Auth;
+}
+
+export default function Promotion() {
+    const { auth } = usePage<PageProps>().props;
+    return (
+        <AppLayout breadcrumbs={breadcrumbs} role={auth.user.role as RoleProps}>
+            <Head title="Promotion" />
+            <div className="flex h-full w-full items-center justify-center p-4">
+                <img src={Poster} alt="Promotional Bonus" className="max-w-full" />
+            </div>
+        </AppLayout>
+    );
+}

--- a/routes/client.php
+++ b/routes/client.php
@@ -11,6 +11,7 @@ use App\Http\Controllers\RequestFund\RequestFundController;
 use App\Http\Controllers\Transferfund\TransferfundController;
 use App\Http\Controllers\Withdraw\WithdrawController;
 use App\Http\Controllers\Coupon\CouponController;
+use App\Http\Controllers\Promotion\PromotionController;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
@@ -29,6 +30,9 @@ Route::get('deposit-history', [DepositHistoryController::class, 'index'])->name(
 Route::get('withdraw', [WithdrawController::class, 'index']);
 Route::post('postwithdraw', [WithdrawController::class, 'postWithdraw']);
 Route::get('withdraw-history', [WithdrawController::class, 'indexHistory'])->name('withdraw-history');
+
+// promotion page
+Route::get('promotion', [PromotionController::class, 'index'])->name('promotion');
 
 //transfer fund module
 Route::get('transfer-fund', [TransferfundController::class, 'index']);


### PR DESCRIPTION
## Summary
- install PHP with composer
- add a Promotion controller and page
- register promotion route
- add Promotion button in sidebar navigation

## Testing
- `npm run lint` *(fails: Unexpected any)*
- `npm run types` *(fails: Parsing error)*
- `./vendor/bin/pest` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_6856a2f947cc832d9569a9184713c066