### PR TITLE
Fix missing referral check

### DIFF
--- a/app/Http/Controllers/Settings/ProfileController.php
+++ b/app/Http/Controllers/Settings/ProfileController.php
@@ -23,7 +23,8 @@ class ProfileController extends Controller
     public function edit(Request $request): Response
     {
         $user = Auth::user();
-        $referral_used = ReferralList::where('user_id', $user->id)->first()->ref_user_username;
+        $referral = ReferralList::where('user_id', $user->id)->first();
+        $referral_used = $referral?->ref_user_username;
 
         return Inertia::render('settings/profile', [
             'mustVerifyEmail' => $request->user() instanceof MustVerifyEmail,

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -24,7 +24,9 @@ class UserFactory extends Factory
     public function definition(): array
     {
         return [
+            'username' => fake()->unique()->userName(),
             'name' => fake()->name(),
+            'gender' => fake()->randomElement(['m', 'f', 'o']),
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),


### PR DESCRIPTION
## Summary
- install PHP and composer packages
- add missing username and gender fields in the user factory
- handle absent referral records in the profile controller

## Testing
- `composer install --no-interaction --prefer-dist`
- `npm install`
- `npm run build`
- `./vendor/bin/pest` *(fails: Unable to locate file in Vite manifest)*
- `curl -I http://127.0.0.1:8000/settings/profile`

------
https://chatgpt.com/codex/tasks/task_e_685903ef963c832dbfb053adae1e1d64