### PR TITLE
Update admin transfer history display

### DIFF
--- a/app/Http/Controllers/AdminTransferFunds/AdminTransferFundsController.php
+++ b/app/Http/Controllers/AdminTransferFunds/AdminTransferFundsController.php
@@ -21,9 +21,10 @@ class AdminTransferFundsController extends Controller
             'b.name as sender',
             'c.name as receiver',
             'a.created_at as date',
-           
+
         )
         // ->where('a.status', 'approved') // Uncomment if you want to add a filter for user status
+        ->orderByDesc('a.created_at')
         ->get();
 
     return Inertia::render('admin/admin-transfer-funds', [

--- a/resources/js/components/admin/admin-transfer-funds/admin-transfer-funds-tab.tsx
+++ b/resources/js/components/admin/admin-transfer-funds/admin-transfer-funds-tab.tsx
@@ -6,14 +6,12 @@ import {
     flexRender,
     getCoreRowModel,
     getFilteredRowModel,
-    getPaginationRowModel,
     getSortedRowModel,
     SortingState,
     useReactTable,
     VisibilityState,
 } from '@tanstack/react-table';
 import React from 'react';
-import { Button } from '../../ui/button';
 import { Separator } from '../../ui/separator';
 
 export type TRANSFERFUNDSTYPES = {
@@ -59,7 +57,6 @@ const AdminTransferFundsTab = ({ data }: { data: TRANSFERFUNDSTYPES[] }) => {
         onSortingChange: setSorting,
         onColumnFiltersChange: setColumnFilters,
         getCoreRowModel: getCoreRowModel(),
-        getPaginationRowModel: getPaginationRowModel(),
         getSortedRowModel: getSortedRowModel(),
         getFilteredRowModel: getFilteredRowModel(),
         onColumnVisibilityChange: setColumnVisibility,
@@ -108,17 +105,7 @@ const AdminTransferFundsTab = ({ data }: { data: TRANSFERFUNDSTYPES[] }) => {
             </Table>
             <Separator orientation="horizontal" />
             <div className="mx-2 flex items-center justify-end space-x-2 py-4">
-                <div className="text-muted-foreground flex-1 text-sm">
-                    {table.getFilteredSelectedRowModel().rows.length} of {table.getFilteredRowModel().rows.length} row(s) selected.
-                </div>
-                <div className="space-x-2">
-                    <Button variant="outline" size="sm" onClick={() => table.previousPage()} disabled={!table.getCanPreviousPage()}>
-                        Previous
-                    </Button>
-                    <Button variant="outline" size="sm" onClick={() => table.nextPage()} disabled={!table.getCanNextPage()}>
-                        Next
-                    </Button>
-                </div>
+                <div className="text-muted-foreground flex-1 text-sm">{table.getRowModel().rows.length} record(s) found.</div>
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary
- sort transfer history by newest first on the admin dashboard
- remove pagination controls for admin transfer history to show a single page
- install PHP and composer dependencies

## Testing
- `php -l app/Http/Controllers/AdminTransferFunds/AdminTransferFundsController.php`
- `npx prettier --check resources/js/components/admin/admin-transfer-funds/admin-transfer-funds-tab.tsx`
- `npx eslint resources/js/components/admin/admin-transfer-funds/admin-transfer-funds-tab.tsx`


------
https://chatgpt.com/codex/tasks/task_e_685d5686ae10832da83d0892948620c0