### PR TITLE
Fix link for franchise application

### DIFF
--- a/resources/js/components/client/franchise-application-info.tsx
+++ b/resources/js/components/client/franchise-application-info.tsx
@@ -61,7 +61,7 @@ export default function FranchiseApplication() {
         {/* CALL TO ACTION */}
         <div className="text-center mt-10">
           <Link
-            href="/franchise/apply"
+            href="/franchise-application"
             className="inline-block px-6 py-3 bg-red-600 hover:bg-red-700 text-white font-semibold rounded-full shadow-md transition duration-200"
           >
             🖊️ Start Application


### PR DESCRIPTION
## Summary
- update FranchiseApplication info page to point to `/franchise-application`

## Testing
- `npm run lint` *(fails: Unexpected any etc.)*
- `php artisan test` *(fails: MissingAppKeyException)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68739013b7bc832da08491ac6c81b1da